### PR TITLE
feature/VCLTJV-2-add superAdmin API getUserByAccessKey

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group 'com.scality'
-version '0.4.0-SNAPSHOT'
+version '0.5.0-SNAPSHOT'
 description = 'vaultclient-java'
 sourceCompatibility = '1.8'
 

--- a/vaultclient/build.gradle
+++ b/vaultclient/build.gradle
@@ -14,7 +14,7 @@ test {
 }
 
 group 'com.scality'
-version '0.4.0-SNAPSHOT'
+version '0.5.0-SNAPSHOT'
 artifacts {
     archives jar
 }
@@ -23,7 +23,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId 'com.scality'
             artifactId 'vaultclient'
-            version '0.4.0-SNAPSHOT'
+            version '0.5.0-SNAPSHOT'
 
             from components.java
 

--- a/vaultclient/src/main/java/com/scality/vaultclient/dto/GetUserByAccessKeyRequestDTO.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/dto/GetUserByAccessKeyRequestDTO.java
@@ -1,0 +1,18 @@
+package com.scality.vaultclient.dto;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class GetUserByAccessKeyRequestDTO extends com.amazonaws.AmazonWebServiceRequest implements Serializable {
+    private static final long serialVersionUID = -2303133786158189623L;
+
+    @NonNull
+    private String accessKey;
+}

--- a/vaultclient/src/main/java/com/scality/vaultclient/dto/GetUserByAccessKeyRequestMarshaller.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/dto/GetUserByAccessKeyRequestMarshaller.java
@@ -1,0 +1,46 @@
+package com.scality.vaultclient.dto;
+
+import com.amazonaws.protocol.MarshallLocation;
+import com.amazonaws.protocol.MarshallingInfo;
+import com.amazonaws.protocol.MarshallingType;
+import com.amazonaws.protocol.ProtocolRequestMarshaller;
+import com.amazonaws.util.StringUtils;
+import com.scality.vaultclient.services.VaultClientException;
+
+/**
+ * The type Create account request marshaller extends GenericRequestMarshaller to marshall Create Account Requests.
+ */
+public class GetUserByAccessKeyRequestMarshaller extends GenericRequestMarshaller<GetUserByAccessKeyRequestDTO>{
+
+    private static final MarshallingInfo<String> ACCESS_KEY_BINDING = MarshallingInfo.builder(MarshallingType.STRING).marshallLocation(MarshallLocation.PAYLOAD)
+            .marshallLocationName("accessKey").build();
+    private static final String GET_USER_BY_ACCESS_KEY_ACTION = "GetUserByAccessKey";
+
+    private static final GetUserByAccessKeyRequestMarshaller instance = new GetUserByAccessKeyRequestMarshaller();
+
+    public static GetUserByAccessKeyRequestMarshaller getInstance() {
+        return instance;
+    }
+
+    /**
+     * Binds protocolMarshaller with createAccountRequestDTO parameters to marshall.
+     *
+     * @param getUserByAccessKeyRequestDTO         the request dto of type GetUserByAccessKeyRequestDTO
+     * @param protocolMarshaller the protocol marshaller
+     */
+    @Override
+    public void marshall(GetUserByAccessKeyRequestDTO getUserByAccessKeyRequestDTO, ProtocolRequestMarshaller<GetUserByAccessKeyRequestDTO> protocolMarshaller) {
+
+        super.marshall(getUserByAccessKeyRequestDTO, protocolMarshaller, GET_USER_BY_ACCESS_KEY_ACTION);
+
+        if (StringUtils.isNullOrEmpty(getUserByAccessKeyRequestDTO.getAccessKey())) {
+            throw new VaultClientException("accessKey is required.");
+        }
+
+        try {
+            protocolMarshaller.marshall(getUserByAccessKeyRequestDTO.getAccessKey(), ACCESS_KEY_BINDING);
+        } catch (Exception e) {
+            throw new VaultClientException("Unable to marshall request to JSON: " + e.getMessage(), e);
+        }
+    }
+}

--- a/vaultclient/src/main/java/com/scality/vaultclient/dto/GetUserByAccessKeyResponseDTO.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/dto/GetUserByAccessKeyResponseDTO.java
@@ -1,0 +1,11 @@
+package com.scality.vaultclient.dto;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class GetUserByAccessKeyResponseDTO implements Serializable {
+    private static final long serialVersionUID = 620924237899261417L;
+    UserData data;
+}

--- a/vaultclient/src/main/java/com/scality/vaultclient/dto/User.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/dto/User.java
@@ -1,0 +1,11 @@
+package com.scality.vaultclient.dto;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class User implements Serializable {
+    private static final long serialVersionUID = 1L;
+    UserData data;
+}

--- a/vaultclient/src/main/java/com/scality/vaultclient/dto/UserData.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/dto/UserData.java
@@ -1,0 +1,17 @@
+package com.scality.vaultclient.dto;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.Date;
+
+@Data
+public class UserData implements Serializable {
+    private static final long serialVersionUID = 1L;
+    String arn;
+    String name;
+    String emailAddress;
+    String id;
+    Date createDate;
+    String parentId;
+}

--- a/vaultclient/src/main/java/com/scality/vaultclient/services/AccountServices.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/services/AccountServices.java
@@ -37,10 +37,19 @@ public interface AccountServices {
     Response<AccountData> getAccount(GetAccountRequestDTO getAccountRequestDTO);
 
     /**
-     * List accounts.
+     * generate account access key.
      *
      * @param generateAccountAccessKeyRequest the generate account access key request dto
      * @return the Generate Account Access Key response
      */
     Response<GenerateAccountAccessKeyResponse> generateAccountAccessKey(GenerateAccountAccessKeyRequest generateAccountAccessKeyRequest);
+
+    /**
+     * Get User By accessKey.
+     *
+     * @param getUserByAccessKeyRequestDTO the Get User by AccessKey request dto
+     * @return the Get User by AccessKey response
+     */
+    Response<GetUserByAccessKeyResponseDTO> getUserByAccessKey(GetUserByAccessKeyRequestDTO getUserByAccessKeyRequestDTO);
+
 }

--- a/vaultclient/src/main/java/com/scality/vaultclient/services/AccountServicesClient.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/services/AccountServicesClient.java
@@ -125,6 +125,6 @@ public class AccountServicesClient extends BaseServicesClient implements Account
 
     @Override
     public Response<GetUserByAccessKeyResponseDTO> getUserByAccessKey(GetUserByAccessKeyRequestDTO getUserByAccessKeyRequestDTO) {
-        return execute(getUserByAccessKeyRequestDTO, "GetUserByAccessKey", GetUserByAccessKeyRequestMarshaller.getInstance(), GetUserByAccessKeyResponseDTO.class );
+        return execute(getUserByAccessKeyRequestDTO, "GetUserByAccessKey", GetUserByAccessKeyRequestMarshaller.getInstance(), GetUserByAccessKeyResponseDTO.class);
     }
 }

--- a/vaultclient/src/main/java/com/scality/vaultclient/services/AccountServicesClient.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/services/AccountServicesClient.java
@@ -122,4 +122,9 @@ public class AccountServicesClient extends BaseServicesClient implements Account
     public AccountServicesClient(AmazonHttpClient client, AWSCredentials awsCredentials) {
         super(client, awsCredentials);
     }
+
+    @Override
+    public Response<GetUserByAccessKeyResponseDTO> getUserByAccessKey(GetUserByAccessKeyRequestDTO getUserByAccessKeyRequestDTO) {
+        return execute(getUserByAccessKeyRequestDTO, "GetUserByAccessKey", GetUserByAccessKeyRequestMarshaller.getInstance(), GetUserByAccessKeyResponseDTO.class );
+    }
 }

--- a/vaultclient/src/test/java/com/scality/vaultclient/services/GetUserByAccessKeyServiceTest.java
+++ b/vaultclient/src/test/java/com/scality/vaultclient/services/GetUserByAccessKeyServiceTest.java
@@ -1,0 +1,90 @@
+package com.scality.vaultclient.services;
+
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.http.AmazonHttpClient;
+import com.scality.vaultclient.dto.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Date;
+
+import static com.scality.vaultclient.utils.VaultServicesTestConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class GetUserByAccessKeyServiceTest {
+
+    // mock vault client
+    protected static AmazonHttpClient getUserByAccessKeyAmazonHttpClient;
+
+    // dummy Aws credentials
+    protected static BasicAWSCredentials basicAWSCredentials;
+
+    // Service
+    protected static AccountServicesClient getUserByAccessKeyMockClient;
+
+    @BeforeAll
+    public static void init() throws Exception{
+
+        basicAWSCredentials = new BasicAWSCredentials("accesskey", "secretkey");
+
+        initGetUserByAccessKeyMocks();
+
+    }
+
+    private static void initGetUserByAccessKeyMocks() {
+
+        getUserByAccessKeyAmazonHttpClient = mock(AmazonHttpClient.class);
+        getUserByAccessKeyMockClient = new AccountServicesClient(getUserByAccessKeyAmazonHttpClient);
+
+        //Default Get Account mock response
+        when(getUserByAccessKeyAmazonHttpClient.execute(any(Request.class), any(), any(), any(),any()))
+                .thenAnswer(new Answer<Response>() {
+                    @Override
+                    public Response<GetUserByAccessKeyResponseDTO> answer(InvocationOnMock invocation) {
+
+                        UserData data = new UserData();
+                        data.setEmailAddress(DEFAULT_USER_EMAIL_ADDR);
+                        data.setName(DEFAULT_USER_NAME);
+                        data.setArn(DEFAULT_USER_ARN_STR);
+                        data.setCreateDate(new Date());
+                        data.setId(DEFAULT_USER_ID);
+                        final GetUserByAccessKeyResponseDTO response = new GetUserByAccessKeyResponseDTO();
+                        response.setData(data);
+                        return new Response<GetUserByAccessKeyResponseDTO>(response,null);
+                    }
+                });
+    }
+
+    /** Get AccountData Test cases **/
+    @Test
+    public void testGetUserByAccessKey() throws Exception {
+        GetUserByAccessKeyRequestDTO getUserByAccessKeyRequestDTO = GetUserByAccessKeyRequestDTO.builder()
+                .accessKey(TEST_ACCESS_KEY)
+                .build();
+
+        GetUserByAccessKeyResponseDTO response = getUserByAccessKeyMockClient.getUserByAccessKey(getUserByAccessKeyRequestDTO).getAwsResponse();
+
+        assertEquals(DEFAULT_USER_EMAIL_ADDR, response.getData().getEmailAddress(), ERR_EMAIL_ADDR_INVALID);
+        assertEquals(DEFAULT_USER_NAME, response.getData().getName(), ERR_NAME_INVALID);
+        assertEquals(DEFAULT_USER_ARN_STR, response.getData().getArn(), ERR_ARN_NULL);
+        assertNotNull(response.getData().getCreateDate(), ERR_CREATE_DATE_NULL);
+        assertEquals(DEFAULT_USER_ID, response.getData().getId(), ERR_ID_NULL);
+    }
+
+    @Test
+    public void testGetUserByAccessKeyWithInvalidRequest(){
+        GetUserByAccessKeyRequestDTO getUserByAccessKeyRequestDTO = GetUserByAccessKeyRequestDTO.builder()
+                .accessKey("")
+                .build();
+
+        assertThrows(SdkClientException.class, () -> {
+            getUserByAccessKeyMockClient.getUserByAccessKey(getUserByAccessKeyRequestDTO).getAwsResponse();
+        }, "Expected SdkClientException");
+    }
+}

--- a/vaultclient/src/test/java/com/scality/vaultclient/utils/VaultServicesTestConstants.java
+++ b/vaultclient/src/test/java/com/scality/vaultclient/utils/VaultServicesTestConstants.java
@@ -3,14 +3,14 @@ package com.scality.vaultclient.utils;
 public final class VaultServicesTestConstants {
 
     public static final String DEFAULT_ACCOUNT_ID = "123123123123";
-    public static final String DEFAULT_ARN_STR = "\"arn:aws:iam::123123123123:/";
+    public static final String DEFAULT_ARN_STR = "arn:aws:iam::123123123123:/";
     public static final String DEFAULT_CANONICAL_ID = "31e38bcfda3ab1887587669ee25a348cc89e6e2e87dc38088289b1b3c5329b30";
     public static final String DEFAULT_ACCOUNT_NAME = "Account5425";
     public static final String DEFAULT_EMAIL_ADDR = "xyz@scality.com";
 
     public static final String DEFAULT_USER_ID = "456456456456";
     public static final String DEFAULT_USER_NAME = "User456";
-    public static final String DEFAULT_USER_ARN_STR = "\"arn:aws:iam::123123123123:user/User456";
+    public static final String DEFAULT_USER_ARN_STR = "arn:aws:iam::123123123123:user/User456";
     public static final String DEFAULT_USER_EMAIL_ADDR = "User456@scality.com";
 
     public static final int DEFAULT_LIST_ACCOUNTS_COUNT = 10;

--- a/vaultclient/src/test/java/com/scality/vaultclient/utils/VaultServicesTestConstants.java
+++ b/vaultclient/src/test/java/com/scality/vaultclient/utils/VaultServicesTestConstants.java
@@ -3,14 +3,15 @@ package com.scality.vaultclient.utils;
 public final class VaultServicesTestConstants {
 
     public static final String DEFAULT_ACCOUNT_ID = "123123123123";
-
     public static final String DEFAULT_ARN_STR = "\"arn:aws:iam::123123123123:/";
-
     public static final String DEFAULT_CANONICAL_ID = "31e38bcfda3ab1887587669ee25a348cc89e6e2e87dc38088289b1b3c5329b30";
-
     public static final String DEFAULT_ACCOUNT_NAME = "Account5425";
-
     public static final String DEFAULT_EMAIL_ADDR = "xyz@scality.com";
+
+    public static final String DEFAULT_USER_ID = "456456456456";
+    public static final String DEFAULT_USER_NAME = "User456";
+    public static final String DEFAULT_USER_ARN_STR = "\"arn:aws:iam::123123123123:user/User456";
+    public static final String DEFAULT_USER_EMAIL_ADDR = "User456@scality.com";
 
     public static final int DEFAULT_LIST_ACCOUNTS_COUNT = 10;
     public static final int TEST_LIST_ACCOUNTS_MARKER_VAL = 2;


### PR DESCRIPTION
the full context is described [in this TAD](https://scality.atlassian.net/wiki/spaces/OS/pages/1958838282/Vault+superAdmin+API+getUserByAccessKey+for+supporting+non+standard+VMware+VCD+OSE+updateCredentialStatus)

simply to say, VMware doesn't follow their API standard for the `updateCredentialStatus` API, so we need to find a workaround to be able to get the user and account information by a given accessKey(accessKey is unique cross the db), so we introduced this superAdmin API in VAULT and vaultclient.