### PR TITLE
vmware-testing/updateAccountAttributes-accepts empty custom attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ allprojects {
 
     configurations {
         group 'com.scality'
-        version '1.0.0'
+        version '1.1.0'
         if (!project.hasProperty('release')) {
             project.setVersion(project.getVersion() + '-SNAPSHOT')
         }

--- a/vaultclient/src/main/java/com/scality/vaultclient/dto/UpdateAccountAttributesRequestMarshaller.java
+++ b/vaultclient/src/main/java/com/scality/vaultclient/dto/UpdateAccountAttributesRequestMarshaller.java
@@ -43,8 +43,7 @@ public class UpdateAccountAttributesRequestMarshaller extends GenericRequestMars
         try {
             protocolMarshaller.marshall(updateAccountAttributesRequestDTO.getName(), NAME_BINDING);
 
-            if (updateAccountAttributesRequestDTO.getCustomAttributes()!=null
-                    && !updateAccountAttributesRequestDTO.getCustomAttributes().isEmpty()) {
+            if (updateAccountAttributesRequestDTO.getCustomAttributes() != null) {
                 protocolMarshaller.marshall(new Gson().toJson(updateAccountAttributesRequestDTO.getCustomAttributes()), CUSTOM_ATTRIBUTES_BINDING);
             } else {
                 throw new VaultClientException("CustomAttributes is required in Update Account Attributes.");

--- a/vaultclient/src/test/java/com/scality/vaultclient/services/UpdateAccountAttributesServiceTest.java
+++ b/vaultclient/src/test/java/com/scality/vaultclient/services/UpdateAccountAttributesServiceTest.java
@@ -139,6 +139,17 @@ class UpdateAccountAttributesServiceTest {
     }
 
     @Test
+    void testUpdateAccountAttributesRequestWithEmptyCustomAttribute(){
+        UpdateAccountAttributesRequestDTO updateAccountAttributesRequestDTO2 = UpdateAccountAttributesRequestDTO.builder()
+                .name(DEFAULT_ACCOUNT_NAME)
+                .customAttributes(new HashMap<>())
+                .build();
+
+        CreateAccountResponseDTO response = updateAccountAttributesMockClient.updateAccountAttributes(updateAccountAttributesRequestDTO2).getAwsResponse();
+        assertNotNull(response.getAccount().getData().getCustomAttributes(), ERR_CUSTOM_ATTRIBUTES_NULL);
+    }
+
+    @Test
     void testUpdateAccountAttributesRequestWithNullName(){
 
         assertThrows(NullPointerException.class, () -> {


### PR DESCRIPTION
Per new specs for OSIS adapter, we need to be able to accept empty custom attributes for the API UpdateAccountAttributes OSE can send empty custom attributes for PatchTenant request